### PR TITLE
Fix quantiser matrix parsing in MPEG sequence header

### DIFF
--- a/src/object_details.cpp
+++ b/src/object_details.cpp
@@ -2172,11 +2172,11 @@ GRAPHSTUDIO_NAMESPACE_START			// cf stdafx.h for explanation
 
             // Intra Matrix
             UINT8 lim = br.ReadU1();
-            if (lim)
-                shinfo->AddItem(new PropItem(_T("Load Intra Matrix"), CString(_T("Use Standard (1)"))));
+            if (!lim)
+                shinfo->AddItem(new PropItem(_T("Load Intra Matrix"), CString(_T("Use Standard (0)"))));
             else
             {
-                shinfo->AddItem(new PropItem(_T("Load Intra Matrix"), CString(_T("Load (0)"))));
+                shinfo->AddItem(new PropItem(_T("Load Intra Matrix"), CString(_T("Load (1)"))));
                 CString matrix;
                 for(int i=0;i<64;i++)
                 {
@@ -2188,11 +2188,11 @@ GRAPHSTUDIO_NAMESPACE_START			// cf stdafx.h for explanation
 
             // Non Intra Matrix
             UINT8 lnim = br.ReadU1();
-            if (lnim)
-                shinfo->AddItem(new PropItem(_T("Load Non Intra Matrix"), CString(_T("Use Standard (1)"))));
+            if (!lnim)
+                shinfo->AddItem(new PropItem(_T("Load Non Intra Matrix"), CString(_T("Use Standard (0)"))));
             else
             {
-                shinfo->AddItem(new PropItem(_T("Load Non Intra Matrix"), CString(_T("Load (0)"))));
+                shinfo->AddItem(new PropItem(_T("Load Non Intra Matrix"), CString(_T("Load (1)"))));
                 CString matrix;
                 for(int i=0;i<64;i++)
                 {
@@ -2226,7 +2226,7 @@ GRAPHSTUDIO_NAMESPACE_START			// cf stdafx.h for explanation
             UINT8 id = br.ReadU(4);
             if(id == 1)
             {
-                PropItem *shinfo = mtinfo->AddItem(new PropItem(_T("MPEG Sequenz Extension")));
+                PropItem *shinfo = mtinfo->AddItem(new PropItem(_T("MPEG Sequence Extension")));
 
                 // Profile
                 UINT8 profile = br.ReadU(4);


### PR DESCRIPTION
The standards says:

load_intra_quantiser_matrix – This is a one-bit flag which is set to '1' if intra_quantiser_matrix follows. If it is set to '0'
then there is no change in the values that shall be used.

So the code had it backwards.